### PR TITLE
feat: Add documentation of Emotes metadata in Collections contract

### DIFF
--- a/ADR/ADR-74-add-emote-schema.md
+++ b/ADR/ADR-74-add-emote-schema.md
@@ -134,6 +134,11 @@ export type MagicalStandardWearable
 // and so on ...
 ```
 
+##### 5. Extend Collection contract metadata to store the `loop` value
+Since the ADR74 Emotes will have proper categories now, we need to start saving the `loop` value in another field, as it used to be stored as the category in the contract metadata. It will be stored at the end of the current metadata string as `0` (`false`) or `1` (`true`). It's added at the end to avoid introducing breaking changes.
+In summary, for emotes, the metadata stored in the contract will now be:
+`${version}:${type}:${name}:${description}:${category}:${bodyShapeTypes}:${loop}`
+
 ## Benefit
 
 The bigger benefit is that the validation of schemas over the time becomes somehow trivial\*:


### PR DESCRIPTION
This is a change that we introduced recently in order to keep saving the `loop` in the contract's metadata, so it's later on picked by the graph and used for multiple purposes (data analysis, filtering in the mktplace, among others)