### PR TITLE
Update ADR-81-minimum-comms-transport.md

### DIFF
--- a/content/ADR-81-minimum-comms-transport.md
+++ b/content/ADR-81-minimum-comms-transport.md
@@ -68,7 +68,7 @@ type AdapterDisconnectedEvent = {
 }
 
 // PEER_DISCONNECTED
-type AdapterDisconnectedEvent = {
+type PeerDisconnectedEvent = {
   // The ethereum address of the disconnected peer
   address: string
 }


### PR DESCRIPTION
Fix a typo in the ADR-81 definition of `PeerDisconnectedEvent`