### PR TITLE
docs: remove endpoints that wont change and adds the /explorer one

### DIFF
--- a/content/ADR-244-extended-minted-items-addressable.md
+++ b/content/ADR-244-extended-minted-items-addressable.md
@@ -66,25 +66,7 @@ From the specified date onwards, all URNs associated with minted wearables and e
 
 If any URN is received that does not conform to this extended format, the endpoint will reject any attempts to deploy such an entity. 
 
-#### POST /content/entities/active
-
-Starting from the proposed date, if you attempt to use a pointer to fetch an active entity of a minted wearable or emote item, the endpoint will examine the received pointer's structure. It should precisely match the pattern `decentraland:{protocol}:collections-{version}:{contract(0x[a-fA-F0-9]+)}:{itemId}:{tokenId}`.
-
-If the pointer does not adhere to this specified structure, the endpoint will reject the request and respond with a 400 Bad Request status. This regex has been implemented to guarantee the presence of the Token Id property, ensuring proper validation of the request.
-
-#### GET /content/pointer-changes
- 
-Starting from the proposed date, this endpoint will include the extended URN in the pointers property for both minted wearables and emotes that are returned. The new format is as follows: `decentraland:{protocol}:collections-{version}:{contract(0x[a-fA-F0-9]+)}:{itemId}:{tokenId}`.
-
 ### Lambdas
-
-#### GET /lambdas/collections/contents/{urn}/thumbnail
-
-This endpoint will exclusively accept extended URNs when requesting the thumbnail of a minted wearable or emote. If an old URN format is received, the endpoint will respond with a Bad Request 400 error, indicating that the request was not valid.
-
-#### GET /lambdas/collections/contents/{urn}/image
-
-This endpoint will exclusively accept extended URNs when requesting the image of a minted wearable or emote. If an old URN format is received, the endpoint will respond with a Bad Request 400 error, indicating that the request was not valid.
 
 #### GET /lambdas/profiles/{address}
 
@@ -93,6 +75,10 @@ This endpoint will now provide the extended URNs for minted wearables and emotes
 #### POST /lambdas/profiles
 
 This endpoint will now provide the extended URNs for minted wearables and emotes on the respective properties: `avatars[].avatar.wearables` and `avatars[].avatar.emotes`. Prior to this update, the endpoint returned different URN formats. With the change, you can expect to receive extended URNs for a more consistent and comprehensive representation of minted wearables and emotes in the specified properties.
+
+#### GET /explorer/{address}/wearables
+
+This endpoint will provide the two types of URNs: extended and non-extended (_with and without token id respectively_). The non-extended URN will continue to be delivered as it currently does, accessed through `elements[n].urn`. However, the extended URN for each item will now be received at `elements[n].individualData[n].id`.
 
 #### GET /lambdas/users/{address}/wearables
 


### PR DESCRIPTION
Reason of removed endpoints:

- POST /content/entities/active
  - Proposed change: receive extended urns for wearables and emotes to return metadata of the associated active entity
  - Reason about push backing the change: the metadata won’t change between individual minted items, meaning that requesting metadata by Asset type is enough. Also, accepting extended urns will impact on how we cache these entities, drastically growing the size of the cache we are using without benefits since the metadata won’t change per minted item but per asset type.
- GET /content/pointer-changes
  -Proposed change: return extended urns for wearables and emotes metadata that have changed during a specific period of time
  -Reason about push backing the change: the metadata won’t change between individual minted items, meaning that requesting metadata by Asset type is enough
- GET /lambdas/collections/contents/{urn}/thumbnail
  - Proposed change: accept extended urns to return thumbnail of the asset
  - Reason about push backing the change: the thumbnail will be the same for each minted item, meaning that the thumbnail is associated to asset type and won’t change per minted item (all of them will have the same). That’s why calling this endpoint without an extended URN is enough
- GET /lambdas/collections/contents/{urn}/image
  - Proposed change: accept extended urns to return thumbnail of the asset
  - Reason about push backing the change: the image will be the same for each minted item, meaning that the image is associated to asset type and won’t change per minted item (all of them will have the same). That’s why calling this endpoint without an extended URN is enough

Besides, this PR also adds the endpoints used by `explorer` to render the backpack (`GET /explorer/:address/wearables`)