### PR TITLE
fix: change the default animation behaviour

### DIFF
--- a/content/ADR-215-gltfcomponent-sdk-component.md
+++ b/content/ADR-215-gltfcomponent-sdk-component.md
@@ -112,7 +112,9 @@ We can clearly see that regardless of the deployed texture, the glTF model remai
 
 ### Initial state
 
-All animations in a glTF instance MUST be stopped as the default state.
+All animations in a glTF instance MUST be stopped as the default state when a Animator is present in the entity, so the Animator can manually controls the state.
+
+If Animator is not present, only the first animation MUST be played in loop state.
 
 ### Controlling animations
 

--- a/content/ADR-215-gltfcomponent-sdk-component.md
+++ b/content/ADR-215-gltfcomponent-sdk-component.md
@@ -112,7 +112,7 @@ We can clearly see that regardless of the deployed texture, the glTF model remai
 
 ### Initial state
 
-All animations in a glTF instance MUST be stopped as the default state when a Animator is present in the entity, so the Animator can manually controls the state.
+All animations in a glTF instance MUST be stopped as the default state when a Animator is present in the entity, so the Animator can manually control the state.
 
 If Animator is not present, only the first animation MUST be played in loop state.
 


### PR DESCRIPTION
this is how is working since sdk6 and the foundation reference client
more info:  https://docs.decentraland.org/creator/development-guide/3d-model-animations/#automatic-playing