### PR TITLE
fix: update ADR-316 spring bones implementation

### DIFF
--- a/content/ADR-316-wearable-spring-bones.md
+++ b/content/ADR-316-wearable-spring-bones.md
@@ -212,7 +212,6 @@ Catalyst's content validator (`@dcl/content-validator`) enforces the following r
 - The `springBones` value MUST conform to the `SpringBonesData` JSON schema in `@dcl/schemas` (parameter ranges, required fields, `gravityDir` as a 3-tuple of numbers, optional `center`/`isRoot`).
 - Every key in `models` MUST equal the content hash of some current representation's `mainFile`. Filename-keyed entries and stale hashes from prior uploads are rejected.
 - Every bone name in `models[<hash>]` MUST contain the `springbone` token (case-insensitive), matching the discovery rule.
-- Each `models[<hash>]` entry MUST NOT contain more than 12 spring bone entries. Wearables that define more than 12 spring bones per GLB representation are rejected.
 
 Structural and per-parameter range validation is delegated to the schema; the validator only enforces the cross-references that the schema cannot express on its own.
 

--- a/content/ADR-316-wearable-spring-bones.md
+++ b/content/ADR-316-wearable-spring-bones.md
@@ -12,7 +12,7 @@ authors:
 
 ## Abstract
 
-This ADR defines the standard for embedding spring bone physics parameters in Decentraland wearable `.gltf` model files using a glTF vendor extension. Spring bones are extra bones — not part of the base avatar armature — whose transforms are driven by a physics simulation rather than animation clips, enabling hair, earrings, capes, belts, and similar wearable elements to move dynamically in response to avatar locomotion and gravity. A spring root bone is identified by a node name containing `springbone` (case-insensitive) combined with the presence of the `DCL_spring_bone_joint` extension in its glTF node `extensions` field. All descendant bones of a root automatically form its spring chain. The parameter set mirrors the VRM `VRMC_springBone` convention. Colliders are out of scope for this version.
+This ADR defines the standard for adding spring bone physics to Decentraland wearables. Spring bones are extra bones — not part of the base avatar armature — whose transforms are driven by a physics simulation rather than animation clips, enabling hair, earrings, capes, belts, and similar wearable elements to move dynamically in response to avatar locomotion and gravity. Parameters are stored in the wearable item's metadata at `wearable.data.springBones`, keyed by GLB content hash; the `.glb` file itself carries only the bone names and hierarchy. A spring root bone is identified by a node name containing `springbone` (case-insensitive) combined with an `isRoot: true` entry for that node in the metadata. All descendant bones of a root automatically form its spring chain. The parameter set mirrors the VRM `VRMC_springBone` convention. Colliders are out of scope for this version.
 
 ## Context, Reach & Prioritization
 
@@ -27,7 +27,7 @@ This standard affects every system that renders avatars: the Explorer (local and
 **Vocabulary:**
 
 - **Spring bone / jiggle bone / physics bone:** A bone not part of the base armature whose transform is driven by physics simulation.
-- **Spring root bone:** A node that owns a spring configuration. Identified by a node name containing `springbone` (case-insensitive, anywhere in the name) and the presence of the `DCL_spring_bone_joint` extension.
+- **Spring root bone:** A node that owns a spring configuration. Identified by a node name containing `springbone` (case-insensitive, anywhere in the name) combined with an `isRoot: true` entry for that node in the wearable's `data.springBones` metadata.
 - **Spring chain:** The spring root bone and all its glTF node descendants, simulated together.
 - **Chain tip:** The deepest descendant in a spring chain. Acts as the geometric endpoint; its parameters are not used by the simulation.
 - **`center`:** An optional reference node name. When specified, inertia is calculated relative to that node's space rather than world space, preventing excessive sway during locomotion.
@@ -40,53 +40,57 @@ Multiple approaches were considered for where to store spring bone parameters.
 
 Data lives in the root glTF object's `extras` field under a `DCL_springBones` key, with an explicit `springs` array listing chains and joints by node index. This mirrors how VRM's extension is structured.
 
-**Not chosen** because it does not allow creators to set parameters directly in Blender using bone Custom Properties. This approach would require parameters to be entered entirely through the Builder UI or a future Blender plugin, which is an unnecessary constraint. Node-level configuration is natively exported by Blender without any plugin.
+**Not chosen** because it does not allow creators to set parameters directly in Blender using bone Custom Properties, and shares the issues of any in-GLB storage approach described in Option C.
 
-### Option B: Parameters in Item Metadata
-
-Spring bone parameters live in the wearable item's metadata, stored externally as JSON and fetched independently from the `gltf` model at runtime. The model contains only the bone nodes; the physics configuration is not embedded in the file.
-
-```json
-{
-  "springBones": [
-    {
-      "name": "SpringBone_hair_l",
-      "stiffness": 2.0,
-      "gravityPower": 0.3,
-      "gravityDir": [0, -1, 0],
-      "drag": 0.5
-    }
-  ]
-}
-```
-
-**Not chosen** because it introduces two sources of truth that must be kept in sync indefinitely. If a creator renames or restructures bones in their model and re-uploads the `.glb`, the metadata references break silently. This desynchronization risk is structural, it cannot be fully engineered away. Additionally, the Explorer would need to reconcile two separate resources at avatar load time, adding error surface. Backend schema changes and migrations would be required. Creators coming from Blender or any DCC tool would lose any authoring work done outside the Builder, as there is no mechanism to carry node-level properties into external metadata.
-
-### Option C: Node-level `extras`
+### Option B: Node-level `extras`
 
 Physics parameters live directly in each spring root bone's glTF node `extras` field. Chains are inferred at load time from the node hierarchy.
 
-This approach was native to standard glTF and allowed node-level configuration. However, using `extras` for structured data is less formal and makes the intent of the data less clear to tooling and other readers.
+**Not chosen.** Native to standard glTF and allows node-level configuration, but using `extras` for structured data is less formal than a vendor extension. Shares the issues of any in-GLB storage approach described in Option C.
 
-### Option D: Node-level Vendor Extension `DCL_spring_bone_joint`
+### Option C: Node-level Vendor Extension `DCL_spring_bone_joint`
 
 Physics parameters live in a formal glTF vendor extension (`DCL_spring_bone_joint`) within each spring root bone's `extensions` field. Chains are inferred at load time from the node hierarchy. The extension is declared in the root `extensionsUsed` array.
 
+**Not chosen.** This was the original choice, reversed during implementation. It offers clear intent and a Blender-native authoring path, but binds parameter tuning to GLB modification, which produces volatile content hashes on every parameter tweak and AB converter overload, because every parameter save re-enters the asset-bundle conversion queue even when the underlying model geometry is unchanged.
+
+These effects are observed in practice and cannot be engineered away without separating parameters from the binary asset, which is what Option D does.
+
+### Option D: Parameters in Item Metadata — **CHOSEN**
+
+Spring bone parameters live on the wearable item's metadata at `wearable.data.springBones`. The `.glb` carries only the bone _names_ (with the `springbone` token) and the _hierarchy_. Parameters are stored as JSON, validated by `@dcl/schemas`' `SpringBonesData` schema, and read by the Explorer at avatar load time.
+
+```json
+{
+  "version": 1,
+  "models": {
+    "<glbContentHash>": {
+      "SpringBone_hair_left": {
+        "stiffness": 2.0,
+        "gravityPower": 0.8,
+        "gravityDir": [0, -1, 0],
+        "drag": 0.3,
+        "center": "Avatar_Hips",
+        "isRoot": true
+      }
+    }
+  }
+}
+```
+
 This approach provides:
 
-- **Clear intent**: the `extensions` object signals to all tooling that this is structured, spec-driven data
-- **Future-proof**: the `version` field allows for schema evolution without breaking parsing
-- **Authoring simplicity**: node-level configuration works with Blender's native Custom Properties export
-- **No breaking changes**: existing files remain valid; the extension is optional
-- **Vendor flexibility**: we define the schema now and may submit for formal Khronos registration later, but immediate functionality does not require approval
+- **No GLB churn.** Parameter edits never touch the `.glb`. The model's content hash and uploaded bytes are stable across tuning sessions.
+- **No AB converter pressure.** Saves that only change spring bone parameters do not produce a new `.glb` and therefore do not trigger asset-bundle conversion.
+- **Single authoring surface.** All parameter editing happens in the Builder UI with live preview. There is no second pipeline (Blender plugin, DCC export) to maintain or keep in sync.
 
-The trade-off is that chain topology must be reconstructed from the hierarchy at load time rather than read from an explicit list. This is addressed by the `springbone` naming convention, which makes spring bone nodes unambiguous to both artists and tooling.
+The trade-off is that creators cannot author spring bone parameters in Blender or any external DCC tool. This is accepted: bone _discovery_ still happens through the GLB (the `springbone` naming convention is required upstream), but parameter _tuning_ is Builder-only.
 
 ## Specification
 
 ### Node Naming Convention
 
-All spring bone nodes MUST have a name containing the substring `springbone` (case-insensitive). The substring can appear at any position in the name.
+All spring bone nodes MUST have a name containing the substring `springbone` (case-insensitive). The substring can appear at any position in the name. The naming convention is the only signal that travels in the `.glb`; physics parameters travel separately in item metadata.
 
 Examples:
 
@@ -97,60 +101,65 @@ Examples:
 | `springbone_earring_r` | ✓ | Right earring chain root |
 | `ponytail_SPRINGBONE` | ✓ | Ponytail chain root (case-insensitive) |
 | `skirt_1` | ✗ | Not a spring bone (missing "springbone") |
-| `SpringBoneCollider` | ✓ | Valid name, but not a root unless it also has the extension |
+| `SpringBoneCollider` | ✓ | Valid name, but only acts as a root when its metadata entry has `isRoot: true` |
 
-The `springbone` substring is the convention by which artists and tooling identify spring bone nodes in the hierarchy. The Explorer identifies spring root bones by the combination of a node name containing `springbone` (case-insensitive) and the presence of the `DCL_spring_bone_joint` extension. Both signals are required.
+The `springbone` substring is the convention by which artists and tooling identify spring bone nodes in the hierarchy. By itself, the name marks a node as a _candidate_ spring bone. The Explorer treats a candidate as a **spring root** only when the wearable's `data.springBones` metadata contains an entry for that node with `isRoot: true`.
 
 ### Spring Root Bone
 
 A node is a **spring root bone** if and only if:
 
 1. Its name contains the substring `springbone` (case-insensitive), AND
-2. Its `extensions` object contains the `DCL_spring_bone_joint` key
+2. The wearable's `data.springBones.models[<glbContentHash>]` contains an entry for the node's name with `isRoot: true`.
+
+Both signals are required. A node that satisfies the naming rule but has no matching metadata entry (or whose entry sets `isRoot: false`) is treated as a chain member, not a root.
 
 The spring chain owned by a root consists of the root bone itself and all its glTF node descendants, traversed depth-first.
 
 Each node in a spring chain SHOULD have at most one child that is also part of the chain, forming a linear sequence from root to tip. Branching topologies — where a node has more than one spring bone child — are not enforced against but MAY produce unexpected simulation behavior.
 
-### Node Extension Schema
+### Item Metadata Schema
+
+Spring bone parameters live on `wearable.data.springBones` and follow the JSON schema defined by `SpringBonesData` in `@dcl/schemas`:
 
 ```json
 {
-  "extensionsUsed": ["DCL_spring_bone_joint"],
-  "nodes": [
-    {
-      "name": "SpringBone_hair_left",
-      "extensions": {
-        "DCL_spring_bone_joint": {
-          "version": 1,
-          "stiffness": 1.0,
-          "gravityPower": 1.0,
-          "gravityDir": [0, -1, 0],
-          "drag": 0.5,
-          "isRoot": true,
-          "center": "Avatar_Hips"
-        }
+  "version": 1,
+  "models": {
+    "<glbContentHash>": {
+      "SpringBone_hair_left": {
+        "stiffness": 2.0,
+        "gravityPower": 0.8,
+        "gravityDir": [0, -1, 0],
+        "drag": 0.3,
+        "center": "Avatar_Hips",
+        "isRoot": true
       }
     }
-  ]
+  }
 }
 ```
 
-The `DCL_spring_bone_joint` extension object resides within a node's `extensions` field. All parameters are OPTIONAL. When absent, the defaults defined below apply. The root glTF object MUST declare `DCL_spring_bone_joint` in its `extensionsUsed` array if any node uses this extension.
+- `version` MUST be exactly `1`.
+- `models` is keyed by the **GLB content hash** — the value found in `WearableEntity.content[<representation.mainFile>]`. Wearables whose male and female representations point at the same `.glb` bytes resolve to one entry; entries are stable across path renames.
+- Inner keys are spring bone names exactly as they appear in the `.glb` (case-sensitive match against the GLB node `name`).
 
 ### Parameter Reference
 
+`version` is a top-level field of `SpringBonesData` and MUST be `1`.
+
+The following per-bone parameters apply to each entry in `models[<hash>]`:
+
 | Parameter | Type | Range | Default | Description |
 | --- | --- | --- | --- | --- |
-| `version` | integer | ≥ 1 | required (must be 1) | Schema version for forward compatibility. Current version is `1`. Required to identify the extension schema variant. |
-| `stiffness` | float | ≥ 0 | `1.0` | Rigidity, how strongly the bone returns to its rest pose. `0` = fully loose, follows gravity only. Higher values = firmer, follows the body more closely. |
-| `gravityPower` | float | ≥ 0 | `1.0` | Magnitude of the gravity force applied to the bone every frame. `0` = unaffected by gravity. |
-| `gravityDir` | vec3 normalized | — | `[0, -1, 0]` | Direction of the gravity force in world space. Default simulates natural downward gravity. Can be used to simulate wind or a floating effect. |
-| `drag` | float | 0–1 | `0.5` | Deceleration / damping. `0` = bone swings freely for a long time. `1` = bone settles almost instantly. |
-| `isRoot` | boolean | — | `true` | Declares whether this node is the root of a spring chain (`true`) or a chain member that overrides inherited parameters (`false`). |
-| `center` | string (node name) | valid node name | none | OPTIONAL. Name of a reference bone node. When set, inertia is evaluated relative to that node's space, preventing excessive sway during locomotion. The referenced node MUST exist and MUST NOT be part of any spring chain. |
+| `stiffness` | float | `0–4` | `2.0` | Rigidity; how strongly the bone returns to its rest pose. `0` = fully loose, follows gravity only. Higher values = firmer, follows the body more closely. |
+| `gravityPower` | float | `0–2` | `0` | Magnitude of the gravity force applied to the bone every frame. `0` = unaffected by gravity. |
+| `gravityDir` | `[number, number, number]` | unit vector | `[0, -1, 0]` | Direction of the gravity force in world space. Default simulates natural downward gravity. Can be used to simulate wind or a floating effect. The Explorer MUST normalize the vector if it is not already a unit vector. |
+| `drag` | float | `0–1` | `0.5` | Deceleration / damping. `0` = bone swings freely for a long time. `1` = bone settles almost instantly. |
+| `isRoot` | boolean | — | OPTIONAL | Declares whether this node is the root of a spring chain (`true`) or a chain member that overrides inherited parameters (`false` or absent). Required to be `true` for a node to be treated as a spring root (see Spring Root Bone). |
+| `center` | string (node name) | valid node name | OPTIONAL | Name of a reference bone node. When set, inertia is evaluated relative to that node's space, preventing excessive sway during locomotion. The referenced node MUST exist and MUST NOT be part of any spring chain. |
 
-`gravityDir` SHOULD be a unit vector. If the provided vector is not normalized, the Explorer MUST normalize it before use.
+Parameter ranges (`stiffness`, `gravityPower`, `drag`) are enforced by the JSON schema in `@dcl/schemas` and verified at deploy time by the content validator (see Deploy-time Validation).
 
 `gravityDir` reference values:
 
@@ -169,26 +178,42 @@ Axes are in **world space**. Diagonal values are valid.
 
 The Explorer MUST reconstruct spring chains at load time using the following procedure:
 
-1. **Extension Declaration Check**: verify that the root `extensionsUsed` array includes `DCL_spring_bone_joint`. If not, no spring bones are present in the file.
-2. **Discovery**: traverse all nodes in the file. Collect every node whose name contains `springbone` (case-insensitive) and whose `extensions` field contains the key `DCL_spring_bone_joint`. The Explorer MAY also use the `isRoot` field to distinguish root bones (`isRoot: true` or absent) from chain members that override inherited parameters (`isRoot: false`).
-3. **Version Check**: for each discovered node, read the `version` field in the extension. If `version` is not `1`, log a warning and skip that node (or handle according to implementation strategy for unknown versions).
-4. **Chain construction**: starting from each discovered node (spring root), collect all descendant nodes depth-first to form the chain. Descendant nodes do not need to carry the extension — they are chain members by hierarchy. If a discovered node is already a descendant of another discovered node, the Explorer MAY discard it as a root and treat it solely as a chain member.
-5. **Tip identification**: the deepest node in each chain is the tip. Its parameters, if any, are not applied by the simulation. It exists solely to define the chain's geometric endpoint.
-6. **Center resolution**: if `center` is specified, resolve the node name. If the name does not correspond to any node in the file, or if it points to a spring bone node, the Explorer SHOULD log a warning and MUST fall back to world space.
+1. **Resolve representation**: pick the wearable representation matching the requested body shape and take its `mainFile`.
+2. **Resolve hash**: look up `mainFile` in the entity's `content` array to obtain the GLB content hash.
+3. **Look up parameters**: read `wearable.data.springBones?.models[hash]`. If absent, no spring bones apply for this representation.
+4. **Version check**: verify that `wearable.data.springBones.version === 1`. If not, log a warning and skip spring bone simulation for this wearable.
+5. **Discovery**: traverse all nodes in the `.glb`. A node is a spring bone candidate iff its name contains `springbone` (case-insensitive). For each candidate, look up its name in the metadata entry. A candidate is a **spring root** iff its metadata entry has `isRoot: true`.
+6. **Chain construction**: starting from each spring root, collect all descendant nodes depth-first to form the chain. Descendant nodes inherit simulation behavior by hierarchy and do not need their own metadata entry. If a candidate is already a descendant of another spring root, the Explorer MAY discard its root status and treat it solely as a chain member.
+7. **Tip identification**: the deepest node in each chain is the tip. Its parameters, if any, are not applied by the simulation. It exists solely to define the chain's geometric endpoint.
+8. **Center resolution**: if `center` is specified, resolve the node name. If the name does not correspond to any node in the file, or if it points to a spring bone node, the Explorer SHOULD log a warning and MUST fall back to world space.
 
 ### Explorer Behaviour
 
-The Explorer MUST apply spring bone simulation to all spring root bones found in any loaded wearable. This applies to the local player's avatar and all other players' avatars in the scene.
+The Explorer MUST apply spring bone simulation to all spring root bones found in any loaded wearable. This applies to the local player's avatar and all other players' avatars in the scene. The Explorer reads spring bone parameters from the wearable's item metadata (`data.springBones`); the `.glb` file is consulted only for bone names and hierarchy.
 
-For performance reasons, the Explorer SHOULD disable spring bone simulation for avatars beyond a distance threshold from the local player. The threshold value is an implementation detail.
+For performance reasons, the Explorer MAY disable spring bone simulation for avatars beyond a distance threshold from the local player. The threshold value is an implementation detail.
 
 Spring bone simulation MUST also be active in all avatar renderers outside the main world, including but not limited to the login screen and the backpack/wearables preview.
 
 ### Builder Behaviour
 
-The Builder MUST detect all spring root bones in an uploaded `.glb` by scanning for nodes whose name contains `springbone` (case-insensitive) and whose `extensions` field contains the key `DCL_spring_bone_joint`. For each detected root, the Builder MUST expose its parameters as editable controls and SHOULD prefill them with the values found in the extension.
+The Builder MUST detect spring bone candidates in an uploaded `.glb` by scanning for nodes whose name contains `springbone` (case-insensitive). For each detected bone, the Builder MUST expose its parameters as editable controls and MAY prefill them with sensible defaults; existing values from the wearable's `data.springBones` metadata SHOULD be used to prefill when present.
 
-When a creator saves changes, the Builder MUST write the updated parameter values back directly into the `DCL_spring_bone_joint` extension object of each affected node in the `.glb`. The `.glb` is always the authoritative source of spring bone configuration.
+When a creator saves changes, the Builder MUST write the updated parameter values into `item.data.springBones.models[<hash>]`, where `<hash>` is the content hash of the representation's `mainFile`. The `.glb` MUST NOT be modified by parameter edits.
+
+The Builder MUST drop entries from `models` whose hash no longer matches any current representation's `mainFile`, so stale parameters from a prior model upload do not persist into a later save.
+
+When a wearable's male and female representations point at the same `.glb` bytes, the Builder MUST write a single entry under that shared hash; there is exactly one parameter set per distinct GLB.
+
+### Deploy-time Validation
+
+Catalyst's content validator (`@dcl/content-validator`) enforces the following rules on `data.springBones` at deployment time. A wearable that fails any of these is rejected:
+
+- The `springBones` value MUST conform to the `SpringBonesData` JSON schema in `@dcl/schemas` (parameter ranges, required fields, `gravityDir` as a 3-tuple of numbers, optional `center`/`isRoot`).
+- Every key in `models` MUST equal the content hash of some current representation's `mainFile`. Filename-keyed entries and stale hashes from prior uploads are rejected.
+- Every bone name in `models[<hash>]` MUST contain the `springbone` token (case-insensitive), matching the discovery rule.
+
+Structural and per-parameter range validation is delegated to the schema; the validator only enforces the cross-references that the schema cannot express on its own.
 
 ### Features Not Included in this version:
 
@@ -204,56 +229,58 @@ The schema is designed to allow future addition of colliders logic and other par
 
 ### Full Example
 
+A complete spring-bone wearable is the combination of two artifacts: the `.glb` (carrying bone names and hierarchy) and the wearable item metadata (carrying parameters).
+
+**`.glb` node hierarchy**:
+
 ```json
 {
   "asset": {"version": "2.0"},
-  "extensionsUsed": ["DCL_spring_bone_joint"],
   "nodes": [
     {"name": "Avatar_Head", "children": [1, 2]},
-    {
-      "name": "SpringBone_earring_r",
-      "children": [3],
-      "extensions": {
-        "DCL_spring_bone_joint": {
-          "version": 1,
-          "stiffness": 0.5,
-          "gravityPower": 1.0,
-          "gravityDir": [0, -1, 0],
-          "drag": 0.6,
-          "isRoot": true,
-          "center": "Avatar_Hips"
-        }
-      }
-    },
-    {
-      "name": "SpringBone_hair_left",
-      "children": [4],
-      "extensions": {
-        "DCL_spring_bone_joint": {
-          "version": 1,
-          "stiffness": 2.0,
-          "gravityPower": 0.8,
-          "gravityDir": [0, -1, 0],
-          "drag": 0.4,
-          "isRoot": true,
-          "center": "Avatar_Hips"
-        }
-      }
-    },
+    {"name": "SpringBone_earring_r", "children": [3]},
+    {"name": "SpringBone_hair_left", "children": [4]},
     {"name": "springbone_earring_r_tip"},
     {"name": "SpringBone_hair_left_tip"}
   ]
 }
 ```
 
+**Wearable item metadata** (`wearable.data.springBones`):
+
+```json
+{
+  "version": 1,
+  "models": {
+    "bafkreialsvt77jvpy673cnugp5ggnxfaalfncufweayuk3jbxskh3pelkm": {
+      "SpringBone_earring_r": {
+        "stiffness": 0.5,
+        "gravityPower": 1.0,
+        "gravityDir": [0, -1, 0],
+        "drag": 0.6,
+        "isRoot": true,
+        "center": "Avatar_Hips"
+      },
+      "SpringBone_hair_left": {
+        "stiffness": 2.0,
+        "gravityPower": 0.8,
+        "gravityDir": [0, -1, 0],
+        "drag": 0.4,
+        "isRoot": true
+      }
+    }
+  }
+}
+```
+
 In this example:
 
-- Root `extensionsUsed` declares `DCL_spring_bone_joint` availability
-- Both nodes `springbone_earring_r` and `SpringBone_hair_left` are spring roots (both contain the extension and have `springbone` in their names)
-- `springbone_earring_r -> springbone_earring_r_tip` hangs from `Ear_R`
-- `SpringBone_hair_left -> SpringBone_hair_left_tip` hangs from `Neck`
-- Both chains reference `Avatar_Hips` by name as their `center`
-- The `_tip` nodes are chain tips and their extension parameters (if any) are ignored by the simulation
+- The `.glb`'s content hash is `bafkrei...pelkm`, used as the outer key of `models`.
+- Both `SpringBone_earring_r` and `SpringBone_hair_left` satisfy the naming rule and have metadata entries with `isRoot: true`, so they are spring roots.
+- `SpringBone_earring_r -> springbone_earring_r_tip` and `SpringBone_hair_left -> SpringBone_hair_left_tip` each form a single chain by hierarchy.
+- Both chains reference `Avatar_Hips` by name as their `center`.
+- The `_tip` nodes are chain tips. They have no metadata entry; the simulation ignores any parameters that might be present on tips.
+- If the same `.glb` is shared across male and female representations, `models` still has a single entry — one per distinct GLB hash.
 
 ## RFC 2119 and RFC 8174
 

--- a/content/ADR-316-wearable-spring-bones.md
+++ b/content/ADR-316-wearable-spring-bones.md
@@ -212,6 +212,7 @@ Catalyst's content validator (`@dcl/content-validator`) enforces the following r
 - The `springBones` value MUST conform to the `SpringBonesData` JSON schema in `@dcl/schemas` (parameter ranges, required fields, `gravityDir` as a 3-tuple of numbers, optional `center`/`isRoot`).
 - Every key in `models` MUST equal the content hash of some current representation's `mainFile`. Filename-keyed entries and stale hashes from prior uploads are rejected.
 - Every bone name in `models[<hash>]` MUST contain the `springbone` token (case-insensitive), matching the discovery rule.
+- Each `models[<hash>]` entry MUST NOT contain more than 12 spring bone entries. Wearables that define more than 12 spring bones per GLB representation are rejected.
 
 Structural and per-parameter range validation is delegated to the schema; the validator only enforces the cross-references that the schema cannot express on its own.
 


### PR DESCRIPTION
## Summary

This pull request updates ADR-316 to change where and how spring bone physics parameters are stored for Decentraland wearables. Instead of embedding parameters in the `.glb` model file via a glTF vendor extension, all spring bone configuration now lives in the wearable item's metadata (`wearable.data.springBones`), keyed by the GLB content hash. The `.glb` file only encodes bone names and hierarchy. This approach reduces asset churn, simplifies parameter editing, and streamlines validation. The document is thoroughly revised to reflect this new standard, including vocabulary, examples, schema, and validation rules.

**Key changes:**

**Spring bone parameter storage and identification:**
- Spring bone physics parameters are now stored in the wearable's metadata at `wearable.data.springBones`, keyed by GLB content hash, rather than as a glTF vendor extension inside the `.glb` file. The `.glb` only contains bone names and hierarchy.
- A spring root bone is identified by a node name containing `springbone` (case-insensitive) and an `isRoot: true` entry for that node in the metadata, not by a glTF extension. [[1]](diffhunk://#diff-bcf8e21dbdf4999f195075672287ceaf337509bfc325b6d90fb878b444a41238L30-R30) [[2]](diffhunk://#diff-bcf8e21dbdf4999f195075672287ceaf337509bfc325b6d90fb878b444a41238L100-R162)

**Specification and schema updates:**
- The document now describes the chosen approach (metadata storage), details the JSON schema for `springBones`, and explains the rationale for not using in-GLB storage methods.
- The metadata schema is defined, including parameter ranges, defaults, and validation requirements. Parameters include `stiffness`, `gravityPower`, `gravityDir`, `drag`, `isRoot`, and `center`.

**Explorer and Builder behavior:**
- The Explorer must read spring bone parameters from metadata, not the `.glb`, and reconstruct chains by matching bone names and hierarchy.
- The Builder must detect spring bone candidates by name, expose parameters for editing, and write changes to metadata. It must also clean up stale entries and handle shared GLBs for male/female representations.

**Validation:**
- Deploy-time validation rules are added: parameters must conform to the schema, all hashes must match current representations, and all bone names must include `springbone`.