### PR TITLE
fix: sign the signed-fetch metadata verbatim instead of folding it

### DIFF
--- a/content/ADR-180-communication-adapters.md
+++ b/content/ADR-180-communication-adapters.md
@@ -81,7 +81,7 @@ Here is the list of officially supported protocols
 
 The signed login exists as part of a "handshake" mechanism to enable authenticated log-ins and access control to different communication services like Livekit.
 
-The verifications of the [signed fetch](/adr/ADR-44) must look for the following properties: `intent`, `signer`, and `isGuest`.
+The verifications of the [signed fetch](/adr/ADR-44) must look for the following properties: `intent`, `signer`, and `isGuest`. These properties are bound to the signature exactly as delivered, so they must be compared exactly: a value or property name differing only in case must be refused rather than case-folded, which would otherwise let a re-spelled property read as absent.
 
 ```typescript
 // connectionString = "signed-login:https://my-server/authenticate-comms"

--- a/content/ADR-289-explorer-client-scenes-signed-fetch.md
+++ b/content/ADR-289-explorer-client-scenes-signed-fetch.md
@@ -44,7 +44,7 @@ This specification impacts:
 
 ### Overview
 
-The Explorer Client Signed Fetch functionality extends [ADR-44](/adr/ADR-44) by including scene-specific metadata in the signature. This metadata is included in the `X-Identity-Metadata` header and is part of the signed payload, ensuring its integrity and authenticity.
+The Explorer Client Signed Fetch functionality extends [ADR-44](/adr/ADR-44) by including scene-specific metadata in the signature. This metadata is included in the `X-Identity-Metadata` header and is part of the signed payload, ensuring its integrity and authenticity. Per [ADR-44](/adr/ADR-44) the metadata is joined into the signed payload **verbatim**, so the property names below — several of which are camelCase — are bound to the signature exactly as written.
 
 ### Signature Metadata Structure
 
@@ -116,6 +116,23 @@ The Signed Fetch process is implemented and executed exclusively within the Expl
 - Scenes cannot change the `signer`, being always `decentraland-kernel-scene`
 
 The Explorer Client validates and populates all metadata fields based on its internal state before generating the signature. This prevents malicious scenes from crafting fraudulent signed requests.
+
+#### Metadata Integrity in Transit
+
+The trust boundary above covers the scene, which cannot reach the metadata the client
+builds. It does not by itself cover the request once it leaves the client: the
+`X-Identity-Metadata` header is delivered as written, so what stops it being rewritten
+in flight is the signature over it.
+
+That holds because [ADR-44](/adr/ADR-44) joins the metadata into the signed payload
+verbatim. Every property here is therefore bound byte-exactly, casing included — which
+matters for this ADR in particular, since `sceneId`, `hashPayload` and
+`realm.serverName` are camelCase and a payload that folded the metadata would have left
+their spelling outside the signature.
+
+Services verifying these requests *MUST* rebuild the payload from the metadata as
+delivered, and *SHOULD* compare a property they authorize on — `signer` above all —
+exactly rather than case-folding it.
 
 #### Request Replay Prevention
 

--- a/content/ADR-44-signed-fetch.md
+++ b/content/ADR-44-signed-fetch.md
@@ -96,9 +96,54 @@ const METADATA: string = JSON.stringify({
 
 /**
  * Payload
+ *
+ * The method and the path are lowercased so a signature does not depend on how a
+ * client happened to spell them. The metadata is joined verbatim: it is a JSON
+ * document whose property names and values are compared exactly by the services
+ * that authorize on them, so its bytes MUST be the bytes that were signed.
  */
+const payload = [METHOD.toLowerCase(), PATH.toLowerCase(), TIMESTAMP, METADATA].join(":")
+```
+
+### Metadata is signed verbatim
+
+The payload above lowercases the method and the path only. Earlier revisions of this
+document folded the whole joined string, metadata included:
+
+```typescript
+// Superseded. Do not use.
 const payload = [METHOD, PATH, TIMESTAMP, METADATA].join(":").toLowerCase()
 ```
+
+Folding after the metadata was joined in left the metadata's casing **outside** the
+signature. `{"signer":"decentraland-kernel-scene"}` and
+`{"Signer":"decentraland-kernel-scene"}` produce a byte-identical payload and therefore
+share one valid signature, while the `X-Identity-Metadata` header is delivered as
+written. A service comparing `metadata.signer` reads the second as *absent* — so a
+request could be re-spelled in flight, keep a valid signature, and bypass a check that
+the property was there to enforce.
+
+Joining the metadata verbatim binds every property name and value — including
+service-defined ones — to the signature, so what is verified is what the handler reads.
+
+Requests are otherwise unchanged: the `X-Identity-Metadata` header still carries the
+same JSON, and only the string that is signed differs.
+
+#### Notes for implementers
+
+- **Signers** *MUST* build the payload as above. `METADATA` *MUST* be the exact string
+  sent in the `X-Identity-Metadata` header — serialize it once and reuse it, rather than
+  re-serializing, since key order and whitespace are part of the signed bytes.
+- **Verifiers** *MUST* rebuild the payload from the metadata exactly as delivered, and
+  *MUST NOT* normalize it before verifying.
+- Verifiers that authorize on a metadata property *SHOULD* compare it exactly rather
+  than case-folding it, so a value that differs only in case is refused rather than
+  read as something it is not.
+- Signers and verifiers are not deployable atomically. A verifier *MAY*, for the length
+  of a migration, fall back to the superseded payload after the current one fails —
+  but only for the properties it authorizes on, and only while refusing a delivered
+  property name that differs from the expected spelling, since the superseded payload
+  cannot bind it. Such a fallback *SHOULD* be removed once its callers have migrated.
 
 ### Sign the payload
 


### PR DESCRIPTION
## Description

ADR-44 specifies the signed-fetch payload as:

```typescript
const payload = [METHOD, PATH, TIMESTAMP, METADATA].join(":").toLowerCase()
```

The fold happens *after* the metadata is joined in, which leaves the metadata's casing **outside** the signature. `{"signer":"decentraland-kernel-scene"}` and `{"Signer":"decentraland-kernel-scene"}` produce a byte-identical payload and therefore share one valid signature — while `X-Identity-Metadata` is delivered exactly as written. A service comparing `metadata.signer` reads the second as *absent*, so a request could be re-spelled in flight, keep a genuinely valid signature, and bypass the check that property was there to enforce.

This amends the specification so the metadata is joined **verbatim**:

```typescript
const payload = [METHOD.toLowerCase(), PATH.toLowerCase(), TIMESTAMP, METADATA].join(":")
```

Method and path are still lowercased, so a signature does not depend on how a client spelled them. Requests are otherwise unchanged — the header carries the same JSON, only the signed string differs.

All three amended documents are status **Living**, which is the status meant to be amended in place rather than superseded.

> This documents behaviour the implementations already have. `@dcl/crypto-middleware` 6.x, `decentraland-crypto-fetch` 3.x, `decentraland-gatsby` 9.x and `dcl-crypto-middleware-rs` 0.3.x all build the payload this way, and the services have been rolled onto them. ADR-44 was the last place still specifying the folded form.

## Changes

**`ADR-44-signed-fetch.md`** — the substantive change.

- The payload now lowercases method and path only and joins the metadata verbatim.
- A new *Metadata is signed verbatim* section explains why, and keeps the superseded form in the document under a `// Superseded. Do not use.` label — implementations still need to recognise it while callers migrate.
- *Notes for implementers* covers what is easy to get wrong: serialize the metadata once and sign the exact bytes sent (key order and whitespace are signed); rebuild the payload from the metadata as delivered and do not normalize it before verifying; compare authorized-on properties exactly rather than case-folding; and if a verifier keeps a fallback to the superseded payload during migration, scope it to the properties it authorizes on and refuse a delivered property name that differs from the expected spelling — because the superseded payload cannot bind it.

**`ADR-289-explorer-client-scenes-signed-fetch.md`** — consistency, not a rewrite.

It states its metadata is part of the signed payload "ensuring its integrity and authenticity", and its fields are camelCase (`sceneId`, `hashPayload`, `realm.serverName`) — precisely what folding left unbound. Its *Security Considerations* covered the client-side trust boundary (scenes cannot reach the metadata the client builds) but not the request once it leaves the client, so a short *Metadata Integrity in Transit* subsection now states that, and the Overview notes the metadata is joined verbatim per ADR-44.

**`ADR-180-communication-adapters.md`** — one sentence.

It requires verifying `intent`, `signer` and `isGuest`, so it now says those comparisons are exact: a value or property name differing only in case must be refused rather than case-folded.

## Checked and deliberately left unchanged

- **ADR-49 (Signed Fetch V2)** — already correct. It concatenates the metadata verbatim (`'x-identity-metadata:' + Metadata`), and its lowercasing applies to header *names* and `Content-Type`, which is correct HTTP canonicalization rather than metadata folding. It is also status Draft.
- **ADR-42, ADR-72** — matched a `lowercase` search but are unrelated (Ethereum address formats; an HTTP method check in a service worker).
- **ADR-183, ADR-208** — mention signed fetch but do not restate the payload construction.

## How to Test

```sh
make build
```

Passes, and ADR-44 / ADR-289 / ADR-180 render with the new sections.
